### PR TITLE
Translate docs/patterns/caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ if you doesn't finish the translation in ten days.
 
 - [ ] appdispatch
 - [ ] appfactories
-- [ ] caching [@pk00749](https://github.com/pk00749) York Li
+- [x] caching [@pk00749](https://github.com/pk00749) York Li
 - [ ] celery
 - [ ] deferredcallbacks
 - [ ] distribute

--- a/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Flask 2.1.x\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-25 19:31+0800\n"
-"PO-Revision-Date: 2021-06-05 13:52+0800\n"
+"PO-Revision-Date: 2021-06-05 15:17+0800\n"
 "Language-Team: zh_CN <withlihui@gmail.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,11 +39,9 @@ msgstr ""
 
 #: ../../patterns/caching.rst:11
 msgid ""
-"Flask itself does not provide caching for you, but `Flask-Caching`_, an "
+"Flask itself does not provide caching for you, but `Flask-Caching <https://flask-caching.readthedocs.io/en/latest/>`_, an "
 "extension for Flask does. Flask-Caching supports various backends, and "
-"it is even possible to develop your own caching backend."
+"it is even possible to develop your own caching backend.
 msgstr ""
 "Flask自身对你不提供缓存，但`Flask-Caching`_，一个Flask的扩展可以做到。"
 "Flask-Caching支持多种后后端，同时甚至可以开发你自己的缓存后端。"
-
-.. _Flask-Caching: https://flask-caching.readthedocs.io/en/latest/

--- a/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
@@ -45,3 +45,5 @@ msgid ""
 msgstr ""
 "Flask自身对你不提供缓存，但`Flask-Caching`_，一个Flask的扩展可以做到。"
 "Flask-Caching支持多种后后端，同时甚至可以开发你自己的缓存后端。"
+
+.. _Flask-Caching: https://flask-caching.readthedocs.io/en/latest/

--- a/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/patterns/caching.po
@@ -3,23 +3,25 @@
 # This file is distributed under the same license as the Flask package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask 2.1.x\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-25 19:31+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2021-06-05 13:52+0800\n"
 "Language-Team: zh_CN <withlihui@gmail.com>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
+"Last-Translator: York H X Li <pk00749@163.com>\n"
+"X-Generator: Poedit 2.4.3\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: en_GB\n"
 
 #: ../../patterns/caching.rst:2
 msgid "Caching"
-msgstr ""
+msgstr "缓存"
 
 #: ../../patterns/caching.rst:4
 msgid ""
@@ -30,11 +32,16 @@ msgid ""
 "that you actually put the result of that calculation into a cache for "
 "some time."
 msgstr ""
+"当你的应用运行缓慢，抛出里面的一些缓存。好吧，至少这是最简单的提速方法。"
+"究竟缓存是做什么？假设你有一个需要消耗一些时间来完成工作的函数，但在5分钟"
+"内完成，结果依然足够好。那么，这个想法是把计算的结果放到缓存里保留一段时"
+"间。"
 
 #: ../../patterns/caching.rst:11
 msgid ""
 "Flask itself does not provide caching for you, but `Flask-Caching`_, an "
-"extension for Flask does. Flask-Caching supports various backends, and it"
-" is even possible to develop your own caching backend."
+"extension for Flask does. Flask-Caching supports various backends, and "
+"it is even possible to develop your own caching backend."
 msgstr ""
-
+"Flask自身对你不提供缓存，但`Flask-Caching`_，一个Flask的扩展可以做到。"
+"Flask-Caching支持多种后后端，同时甚至可以开发你自己的缓存后端。"


### PR DESCRIPTION
Pull request后的test出现一个来自原文docs/pattern/caching的错误。
- Error:
Warning, treated as error:
/home/runner/work/flask-docs-zh/flask-docs-zh/docs/patterns/caching.rst:11:inconsistent references in translated message. original: ['`Flask-Caching`_'], translated: []
ERROR: InvocationError for command /home/runner/work/flask-docs-zh/flask-docs-zh/.tox/docs/bin/sphinx-build -W -b html -d /home/runner/work/flask-docs-zh/flask-docs-zh/.tox/docs/tmp/doctrees docs /home/runner/work/flask-docs-zh/flask-docs-zh/.tox/docs/tmp/html (exited with code 2)

- 原文:
Flask itself does not provide caching for you, but `Flask-Caching`_, an
extension for Flask does. Flask-Caching supports various backends, and it is
even possible to develop your own caching backend.

.. _Flask-Caching: https://flask-caching.readthedocs.io/en/latest/


请问需要修复？不好意思此刻在思考怎么解决




- [x] 在 README.md 中勾选翻译的章节条目（把方括号里的空格替换为 `x`）.
- [x] 在本地生成文档并预览输出，处理所有错误和异常。
- [x] 运行 `pre-commit` 钩子，处理所有问题。
